### PR TITLE
fix(airbnb): fix smart_count tag check crash on single-plural-form languages

### DIFF
--- a/lib/Features/Airbnb.php
+++ b/lib/Features/Airbnb.php
@@ -347,15 +347,15 @@ class Airbnb extends BaseFeature
                 $targetTagMap[] = $itemSegMatch[0];
             }
 
-            foreach ($expectedTargetTagMap as &$tags) {
+            foreach ($expectedTargetTagMap as $i => $tags) {
                 sort($tags);
+                $expectedTargetTagMap[$i] = $tags;
             }
-            unset($tags);
 
-            foreach ($targetTagMap as &$tags) {
+            foreach ($targetTagMap as $i => $tags) {
                 sort($tags);
+                $targetTagMap[$i] = $tags;
             }
-            unset($tags);
 
             $smartCountErrors = 0;
             $tagOrderErrors = 0;

--- a/lib/Features/Airbnb.php
+++ b/lib/Features/Airbnb.php
@@ -347,10 +347,15 @@ class Airbnb extends BaseFeature
                 $targetTagMap[] = $itemSegMatch[0];
             }
 
-            sort($expectedTargetTagMap[0]);
-            sort($expectedTargetTagMap[1]);
-            sort($targetTagMap[0]);
-            sort($targetTagMap[1]);
+            foreach ($expectedTargetTagMap as &$tags) {
+                sort($tags);
+            }
+            unset($tags);
+
+            foreach ($targetTagMap as &$tags) {
+                sort($tags);
+            }
+            unset($tags);
 
             $smartCountErrors = 0;
             $tagOrderErrors = 0;

--- a/tests/unit/Features/AirbnbTest.php
+++ b/tests/unit/Features/AirbnbTest.php
@@ -434,6 +434,53 @@ class AirbnbTest extends AbstractTest
     }
 
     #[Test]
+    public function checkTagMismatch_singlePluralFormLanguage_correctTags_returnsZero(): void
+    {
+        $smartCountTag = '<ph id="mtc_1" ctype="x-smart-count" equiv-text="base64:fHx8fA=="/>';
+        $nameTag = '<ph id="mtc_2" equiv-text="base64:JXtmaXJzdF9uYW1lfQ=="/>';
+
+        // Source (en-US): 2 forms, each containing the name tag.
+        $source = $nameTag . ' has 1 hour' . $smartCountTag . $nameTag . ' has %{count} hours';
+        // Target (zh-CN): 1 plural form only (no smart count separator), same name tag.
+        $target = $nameTag . ' 有 %{count} 小时';
+
+        $qa = $this->createStub(QA::class);
+        $qa->method('getSourceSeg')->willReturn($source);
+        $qa->method('getTargetSeg')->willReturn($target);
+        $qa->method('getTargetSegLang')->willReturn('zh-CN'); // 1 plural form
+
+        $event = new CheckTagMismatchEvent(0, $qa);
+
+        $this->airbnb->checkTagMismatch($event);
+
+        self::assertSame(0, $event->getErrorCode());
+    }
+
+    #[Test]
+    public function checkTagMismatch_singlePluralFormLanguage_tagMismatch_returnsError2001(): void
+    {
+        $smartCountTag = '<ph id="mtc_1" ctype="x-smart-count" equiv-text="base64:fHx8fA=="/>';
+        $nameTag = '<ph id="mtc_2" equiv-text="base64:JXtmaXJzdF9uYW1lfQ=="/>';
+
+        // Source (en-US): 2 forms, each containing the name tag.
+        $source = $nameTag . ' has 1 hour' . $smartCountTag . $nameTag . ' has %{count} hours';
+        // Target (zh-CN): 1 plural form, but missing the name tag.
+        $target = 'has %{count} hours';
+
+        $qa = $this->createMock(QA::class);
+        $qa->method('getSourceSeg')->willReturn($source);
+        $qa->method('getTargetSeg')->willReturn($target);
+        $qa->method('getTargetSegLang')->willReturn('zh-CN'); // 1 plural form
+        $qa->expects(self::once())->method('addCustomError');
+
+        $event = new CheckTagMismatchEvent(0, $qa);
+
+        $this->airbnb->checkTagMismatch($event);
+
+        self::assertSame(QA::SMART_COUNT_MISMATCH, $event->getErrorCode());
+    }
+
+    #[Test]
     public function checkTagMismatch_notQAInstance_earlyReturn(): void
     {
         $event = new CheckTagMismatchEvent(42, new stdClass());


### PR DESCRIPTION
## Summary

- `Features\Airbnb::checkTagMismatch()` crashed with an uncaught `TypeError` (`sort(): Argument #1 ($array) must be of type array, null given`) whenever the target language has a single plural form (e.g. `zh-CN`, `zh-HK`, `zh-TW`, `ms-MY`, `ja-JP`, `ko-KR`, `vi-VN`).
- Root cause: the method built `$expectedTargetTagMap`/`$targetTagMap` with only index `0` populated for 1-plural-form languages (the loop filling index `1+` never runs when `Pluralization::getCountFromLang()` returns `1`), but then unconditionally called `sort($expectedTargetTagMap[1])` / `sort($targetTagMap[1])`, hitting an undefined array key that autovivified to `null`.
- This was a regression: commit `304ac08` ("Fix PHP8.*") previously guarded these calls, but the `f0811e7` ("Context review (#119)") refactor dropped the guards and reintroduced the unconditional `sort()` calls, with no test coverage for 1-plural-form languages.
- Fix: replace the four hardcoded, index-specific `sort()` calls with a loop over whatever elements actually exist in each map, which works uniformly for any plural-form count (1 through 6).

## Test plan

- [x] Added `checkTagMismatch_singlePluralFormLanguage_correctTags_returnsZero` — reproduces the crash pre-fix, passes post-fix.
- [x] Added `checkTagMismatch_singlePluralFormLanguage_tagMismatch_returnsError2001` — confirms real tag mismatches are still correctly detected for 1-form languages.
- [x] Verified regression: temporarily reverted the fix and confirmed both new tests fail with the exact reported `TypeError` at the exact line.
- [x] Full `AirbnbTest.php` + `PluralizationTest.php` suite green (93 tests, 117 assertions).
- [x] `phpstan analyse` on the changed file with no baseline: no errors.