### PR TITLE
♻️ refactor(cattool): assign over core's objects instead of patching prototypes

### DIFF
--- a/static/src/cattool/airbnb-core.extension.js
+++ b/static/src/cattool/airbnb-core.extension.js
@@ -3,12 +3,11 @@ import $ from 'jquery'
 import {isUndefined, forOwn} from 'lodash'
 import SegmentActions from '../../../../../public/js/actions/SegmentActions'
 import SegmentStore from '../../../../../public/js/stores/SegmentStore'
-import SegmentFooterTabMessages from '../../../../../public/js/components/segments/SegmentFooterTabMessages'
-import SegmentFooter from '../../../../../public/js/components/segments/SegmentFooter'
 import SegmentUtils from '../../../../../public/js/utils/segmentUtils'
-import { CatToolInterface } from '../../../../../public/js/pages/CatToolInterface'
 import { CHARS_SIZE_COUNTER_TYPES } from '../../../../../public/js/utils/charsSizeCounterUtil'
 import globalFunctions from '../../../../../public/js/globalFunctions'
+import segmentNotes from '../../../../../public/js/components/segments/segmentNotes'
+import catToolInterface from '../../../../../public/js/pages/CatToolInterface'
 // Override characters size mapping
 
 const AIRBNB_FEATURE = 'airbnb'
@@ -31,9 +30,11 @@ const init = () => {
       return false
     }
   }
-  const originalRegisterFooterTabs = globalFunctions.registerFooterTabs
+  // Add to whatever is registered at this point rather than to core's own
+  // implementation, so another plugin's tabs survive alongside these.
+  const registerPreviousFooterTabs = globalFunctions.registerFooterTabs
   globalFunctions.registerFooterTabs = function () {
-    originalRegisterFooterTabs.apply(this)
+    registerPreviousFooterTabs()
     SegmentActions.registerTab('messages', true, true)
   }
   globalFunctions.getContextBefore = function (segmentId) {
@@ -99,73 +100,65 @@ const init = () => {
     return getSegmentId(segmentAfter)
   }
 
-  function overrideTabMessages(SegmentTabMessages) {
-    const noteStructure = SegmentTabMessages.prototype.getNoteStructure
-    SegmentTabMessages.prototype.getNotes = function () {
-      let notesHtml = []
-      let self = this
-      if (this.props.notes) {
-        this.props.notes.forEach((item, index) => {
-          if (item.note && item.note !== '') {
-            if (item.note.indexOf('¶') === -1) {
-              const noteHtml = noteStructure.call(this, item, index)
-              if (noteHtml) {
-                notesHtml.push(noteHtml)
-              }
-            }
+  const buildNote = segmentNotes.getNote
+  segmentNotes.getNotes = ({notes, metadata, segment, segmentSource}) => {
+    const notesHtml = []
+    if (notes) {
+      notes.forEach((item, index) => {
+        if (item.note && item.note !== '' && item.note.indexOf('¶') === -1) {
+          const noteHtml = buildNote({item, index})
+          if (noteHtml) {
+            notesHtml.push(noteHtml)
           }
-        })
-      }
-      if (this.props.segmentSource.indexOf('"base64:fHx8fA=="') > -1) {
-        //base64 of pipes "||||", now they are in tag form
-        let targetPrefix = config.target_code.split('-')[0]
-        let langLike
-        //Search the dialect
+        }
+      })
+    }
+    if (segmentSource.indexOf('"base64:fHx8fA=="') > -1) {
+      //base64 of pipes "||||", now they are in tag form
+      let targetPrefix = config.target_code.split('-')[0]
+      let langLike
+      //Search the dialect
+      forOwn(PLURAL_TYPE_NAME_TO_LANGUAGES, function (value, key) {
+        if (value.indexOf(config.target_code) !== -1) {
+          langLike = key
+          return false
+        }
+      })
+      // In not search de prefix
+      if (!langLike) {
         forOwn(PLURAL_TYPE_NAME_TO_LANGUAGES, function (value, key) {
-          if (value.indexOf(config.target_code) !== -1) {
+          if (value.indexOf(targetPrefix) !== -1) {
             langLike = key
             return false
           }
         })
-        // In not search de prefix
-        if (!langLike) {
-          forOwn(PLURAL_TYPE_NAME_TO_LANGUAGES, function (value, key) {
-            if (value.indexOf(targetPrefix) !== -1) {
-              langLike = key
-              return false
-            }
-          })
-        }
-        if (!isUndefined(langLike) && PLURAL_TYPES[langLike]) {
-          let rules = PLURAL_TYPES[langLike]
-          let html = (
-            <div className="note" key="forms">
-              <span className="note-label">Plural forms: </span>
-              <span dangerouslySetInnerHTML={self.allowHTML(rules.num_forms)} />
-            </div>
+      }
+      if (!isUndefined(langLike) && PLURAL_TYPES[langLike]) {
+        const rules = PLURAL_TYPES[langLike]
+        notesHtml.push(
+          <div className="note" key="forms">
+            <span className="note-label">Plural forms: </span>
+            <span dangerouslySetInnerHTML={{__html: rules.num_forms}} />
+          </div>,
+        )
+        if (rules.doc && rules.doc.length) {
+          notesHtml.push(
+            <div className="note" key="rules">
+              <span className="note-label">Rules for smart count: </span>
+              <span
+                dangerouslySetInnerHTML={{__html: rules.doc.join(' |||| ')}}
+              />
+            </div>,
           )
-          notesHtml.push(html)
-          if (rules.doc && rules.doc.length) {
-            html = (
-              <div className="note" key="rules">
-                <span className="note-label">Rules for smart count: </span>
-                <span
-                  dangerouslySetInnerHTML={self.allowHTML(
-                    rules.doc.join(' |||| '),
-                  )}
-                />
-              </div>
-            )
-            notesHtml.push(html)
-          }
         }
       }
-      // metadata notes
-      if (this.props.metadata) {
-        notesHtml.push(this.getMetadataNoteTemplate())
-      }
-      return notesHtml
     }
+    // metadata notes
+    if (metadata) {
+      notesHtml.push(segmentNotes.getMetadataNotes({metadata, segment}))
+    }
+    return notesHtml
+  }
 
     var PLURAL_TYPES = {
       chinese_like: {
@@ -417,30 +410,16 @@ const init = () => {
 
       irish_like: ['ga'],
     }
+
+  const originalSegmentHasNote = SegmentUtils.segmentHasNote
+  SegmentUtils.segmentHasNote = (segment) => {
+    const hasOrginalNotes = originalSegmentHasNote(segment)
+    return hasOrginalNotes || segment.segment.indexOf('"base64:fHx8fA=="') > -1
   }
 
-  function overrideSetDefaultTabOpen(SegmentFooter) {
-    SegmentFooter.prototype.setDefaultTabOpen = function () {
-      return false
-    }
-  }
-
-  function ovverrideSegmentUtilFn(SegmentUtils) {
-    const originalFn = SegmentUtils.segmentHasNote
-    SegmentUtils.segmentHasNote = (segment) => {
-      const hasOrginalNotes = originalFn(segment)
-      return (
-        hasOrginalNotes || segment.segment.indexOf('"base64:fHx8fA=="') > -1
-      )
-    }
-  }
-
-  overrideTabMessages(SegmentFooterTabMessages)
-  overrideSetDefaultTabOpen(SegmentFooter)
-  ovverrideSegmentUtilFn(SegmentUtils)
-
-  CatToolInterface.prototype.getCharacterCounterMode = () => CHARS_SIZE_COUNTER_TYPES.EXCLUDE_CJK
+  catToolInterface.getCharacterCounterMode = () =>
+    CHARS_SIZE_COUNTER_TYPES.EXCLUDE_CJK
 }
-document.addEventListener('DOMContentLoaded', function (event) {
+document.addEventListener('DOMContentLoaded', function () {
   if (config.project_plugins.indexOf(AIRBNB_FEATURE) > -1) init()
 })

--- a/static/src/upload/airbnb-upload.extension.js
+++ b/static/src/upload/airbnb-upload.extension.js
@@ -1,10 +1,10 @@
-import { UseProjectTemplateInterface } from "../../../../../public/js/hooks/useProjectTemplates"
 import { CHARS_SIZE_COUNTER_TYPES } from "../../../../../public/js/utils/charsSizeCounterUtil"
+import { useProjectTemplateInterface } from "../../../../../public/js/hooks/useProjectTemplates"
 
 const AIRBNB_FEATURE = 'airbnb'
 
 function init(){
-    UseProjectTemplateInterface.prototype.getCharacterCounterMode = () => CHARS_SIZE_COUNTER_TYPES.EXCLUDE_CJK
+    useProjectTemplateInterface.getCharacterCounterMode = () => CHARS_SIZE_COUNTER_TYPES.EXCLUDE_CJK
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary

Stops this plugin extending the Matecat frontend by patching React component prototypes, and assigns
over the members of core's plain helper objects instead.

The class-to-function migration in core removed the prototypes this plugin used to patch, so the
segment notes tab stopped being overridden at all. Core now keeps the overridable behaviour on
ordinary exported objects — `globalFunctions`, `segmentNotes`, `catToolInterface`,
`useProjectTemplateInterface` — and this plugin replaces the members it cares about. There is no
registry, no manifest and no extension-point vocabulary in core: the call sites read as ordinary
code.

**Depends on matecat/MateCat#4768 and must land with it.** Those objects do not exist on a core
without that PR, and that PR removes the prototypes this plugin used to patch.

## Changes

| Commit | Change |
|--------|--------|
| `a71dcb4` | Replace every prototype patch with an assignment over a member of one of core's helper objects |

What each assignment now targets:

| Member | Was |
|--------|-----|
| `SegmentActions.addGlossaryItem` | unchanged — still the same module property, byte for byte |
| `globalFunctions.registerFooterTabs` | same object |
| `globalFunctions.getContextBefore` / `getContextAfter` / `getIdBefore` / `getIdAfter` | same object |
| `segmentNotes.getNotes` | a patch on the notes-tab component prototype |
| `SegmentUtils.segmentHasNote` | same module property, but now captures whatever is installed and calls it |
| `catToolInterface.getCharacterCounterMode` | mutation of a core constant |
| `useProjectTemplateInterface.getCharacterCounterMode` | mutation of a core constant |

The note-row builder is now taken from core (`segmentNotes.getNote`) instead of being copied, so the
override only supplies the grouping this deployment wants.

Rebased onto `master` after #123 landed, keeping its `config.target_code` rename inside the block this
branch moves off `this.props`.

Two behaviour-neutral drops: the `setDefaultTabOpen` override (core no longer calls it) and the
`this.props` reads inside the overrides — every member is now a plain function of an explicit context
object, so a wrapper can call the previously installed one unbound.

`segmentHasNote` uses capture-then-replace rather than a reference to core's original, so a second
plugin wrapping the same member chains instead of one silently discarding the other.

## One small consequence to note

Core now filters the size-restriction key out of a segment's metadata *before* handing it to an
override, so no override repeats that decision. This plugin's "is there any metadata" check therefore
sees the filtered list: a segment whose only metadata key is the size restriction no longer pushes an
empty metadata block into the notes tab. That block rendered nothing visible, so this should be
invisible in the UI.

## Testing

Core's frontend suite passes in full on the paired branch — 427 suites / 4444 tests / 2 snapshots,
with every coverage threshold met. This repo has no frontend test suite of its own; `eslint` reports
no errors on the changed files, where it previously failed to parse them at all. Every relative
import in the changed files was resolved and every assigned member checked to exist on its core
object.

**Manual QA outstanding.** Needs a live pass on the segment notes tab, the glossary (still read-only
here), the footer tabs and the character counter.

## AI Disclosure

AI tools were used: Claude Code (Sonnet 5, Opus 5).
